### PR TITLE
Yiran fix2

### DIFF
--- a/experiments/CamemBERT/model/CamemBERT.py
+++ b/experiments/CamemBERT/model/CamemBERT.py
@@ -26,7 +26,7 @@ class OnlyLogitsHuggingFaceModel(torch.nn.Module):
     def forward(self, input):
         x = input.reshape(1, 7, 768)
         # Return only the logits.
-        x = self.layer1(input).last_hidden_state
+        x = self.layer1(x).last_hidden_state
         x = self.layer2(x)
         x = self.layer3(x)
         return x
@@ -47,6 +47,7 @@ print("Parsing sentence tokens.")
 example_input = prepare_sentence_tokens(model_name, sentence)
 print("example_input shape: ", example_input.shape)
 
+# The original example_input shape is [1, 7, 768], now we reshape it into [1, 7*768]
 example_input = example_input.reshape(1, 7*768)
 print("example_input shape after reshaping: ", example_input.shape)
 

--- a/experiments/CamemBERT/model/CamemBERT.py
+++ b/experiments/CamemBERT/model/CamemBERT.py
@@ -24,6 +24,7 @@ class OnlyLogitsHuggingFaceModel(torch.nn.Module):
         self.layer3 = AutoModelForTokenClassification.from_pretrained(model_name).classifier
 
     def forward(self, input):
+        x = input.reshape(1, 7, 768)
         # Return only the logits.
         x = self.layer1(input).last_hidden_state
         x = self.layer2(x)
@@ -44,7 +45,10 @@ sentence = "Face à un choc inédit"
 
 print("Parsing sentence tokens.")
 example_input = prepare_sentence_tokens(model_name, sentence)
-print(example_input.shape)
+print("example_input shape: ", example_input.shape)
+
+example_input = example_input.reshape(1, 7*768)
+print("example_input shape after reshaping: ", example_input.shape)
 
 print("Instantiating model.")
 model = OnlyLogitsHuggingFaceModel(model_name)

--- a/experiments/VIT/model/vit.py
+++ b/experiments/VIT/model/vit.py
@@ -25,6 +25,7 @@ class vit(nn.Module):
 		self.layer2 = ViTForImageClassification.from_pretrained('google/vit-base-patch16-224').vit.layernorm
 		self.layer3 = ViTForImageClassification.from_pretrained('google/vit-base-patch16-224').classifier
 	def forward(self,x):
+		x = x.reshape(1, 197, 768)
 		x = self.layer1(x).last_hidden_state
 		x = self.layer2(x)
 		x = self.layer3(x)
@@ -37,6 +38,9 @@ inputs = feature_extractor(images=image, return_tensors="pt").pixel_values
 model = prepare().eval()
 example_input = model(inputs)
 print(example_input.shape)
+example_input = example_input.reshape(1, 197*768)
+print("example_input shape after reshaping: ", example_input.shape)
+
 
 vit_model = vit().eval()
 output = vit_model(example_input)

--- a/experiments/VIT/model/vit.py
+++ b/experiments/VIT/model/vit.py
@@ -38,6 +38,8 @@ inputs = feature_extractor(images=image, return_tensors="pt").pixel_values
 model = prepare().eval()
 example_input = model(inputs)
 print(example_input.shape)
+
+# The original example_input shape is [1, 197, 768], now we reshape it into [1, 197*768]
 example_input = example_input.reshape(1, 197*768)
 print("example_input shape after reshaping: ", example_input.shape)
 


### PR DESCRIPTION
The `example_input` in CamemBERT.py originally is in shape of [1, 7, 768], I reshaped it to [1, 7*768], then I send it to the CamemBERT model. In the `forward` function of CamemBERT model, I first reshape the input back to [1, 7, 768].

The similar things happened to VIT.